### PR TITLE
Add proportionallyAllocateInts

### DIFF
--- a/src/main/scala/io/flow/util/Allocator.scala
+++ b/src/main/scala/io/flow/util/Allocator.scala
@@ -43,6 +43,13 @@ object Allocator {
     case Some(s) => proportionallyAllocateRound(amount, proportions, s)
   }
 
+  def proportionallyAllocateInts(
+    amount: Int,
+    proportions: Seq[BigDecimal],
+  ): Seq[Int] = {
+    proportionallyAllocateRound(amount, proportions, scale = 0).map(_.intValue)
+  }
+
   /**
     * @see [[proportionallyAllocate]]
     */


### PR DESCRIPTION
- Provides an interface with `Int` when you want to allocate exact integers
 - Makes it clear how to use the existing interface with integers. Initially
   took me a couple reads to understand integers work with scale 0