### PR TITLE
Add a safeGet and getOrElse to CacheWithFallbackToStaleData

### DIFF
--- a/src/main/scala/io/flow/util/CacheWithFallbackToStaleData.scala
+++ b/src/main/scala/io/flow/util/CacheWithFallbackToStaleData.scala
@@ -6,7 +6,6 @@ import java.time.temporal.ChronoField
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
-import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 private[util] case class CacheEntry[V](value: V, expiresAt: ZonedDateTime) {
@@ -104,7 +103,7 @@ trait CacheWithFallbackToStaleData[K, V] {
   def safeGet(key: K): Try[V] = Try(get(key))
 
   /**
-   * Returns the `default` value if the underlying call to [[get]] returns an exception
+   * Returns the `default` value if the underlying call to [[get]] throws an exception
    */
   def getOrElse(key: K, default: => V): V = safeGet(key).getOrElse(default)
 

--- a/src/main/scala/io/flow/util/CacheWithFallbackToStaleData.scala
+++ b/src/main/scala/io/flow/util/CacheWithFallbackToStaleData.scala
@@ -6,6 +6,7 @@ import java.time.temporal.ChronoField
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 private[util] case class CacheEntry[V](value: V, expiresAt: ZonedDateTime) {
@@ -18,7 +19,7 @@ private[util] case class CacheEntry[V](value: V, expiresAt: ZonedDateTime) {
   * Caches data for a short period of time (configurable, defaults to 1 minute)
   *
   * Refreshes data on demand (when you call `get`, if entry is not in cache
-  * executes the refresh function then). If the call to `get` failes, and
+  * executes the refresh function then). If the call to `get` fails, and
   * and there is data cached in memory, you will get back the stale data.
   */
 trait CacheWithFallbackToStaleData[K, V] {
@@ -49,6 +50,14 @@ trait CacheWithFallbackToStaleData[K, V] {
   private[this] lazy val durationSeconds = duration.toSeconds
   private[this] lazy val durationForNoneSeconds = durationForNone.toSeconds
 
+  /**
+   * Indicates how to fetch the value for a given key.
+   * This function is called when the key is not cached or the value has expired.
+   *
+   * If the function throws an exception and there is a value in the cache, this stale value will be returned.
+   * Otherwise the exception is thrown and must be handled.
+   * @see [[safeGet]] and [[getOrElse]]
+   */
   def refresh(key: K): V
 
   /**
@@ -62,6 +71,9 @@ trait CacheWithFallbackToStaleData[K, V] {
     ()
   }
 
+  /**
+   * If [[refresh]] may throw an exception when the cache is empty, use [[safeGet]] or [[getOrElse]]
+   */
   def get(key: K): V = {
     // try to do a quick get first
     val finalEntry = Option(cache.get(key)) match {
@@ -84,6 +96,17 @@ trait CacheWithFallbackToStaleData[K, V] {
     }
     finalEntry.value
   }
+
+  /**
+   * Use instead of [[get]] if [[refresh]] may throw an exception.
+   * @see [[getOrElse]] to return a default value
+   */
+  def safeGet(key: K): Try[V] = Try(get(key))
+
+  /**
+   * Returns the `default` value if the underlying call to [[get]] returns an exception
+   */
+  def getOrElse(key: K, default: => V): V = safeGet(key).getOrElse(default)
 
   private[this] def failureFromEmpty(key: K, ex: Throwable): CacheEntry[V] = {
     val msg = s"FlowError for Cache[${this.getClass.getName}] key[$key]: ${ex.getMessage}"

--- a/src/test/scala/io/flow/util/CacheWithFallbackToStaleDataSpec.scala
+++ b/src/test/scala/io/flow/util/CacheWithFallbackToStaleDataSpec.scala
@@ -173,4 +173,23 @@ class CacheWithFallbackToStaleDataSpec extends AnyWordSpecLike with Matchers {
     cache.numberRefreshes must be(2)
   }
 
+  "safeGet" in {
+    val cache = TestCacheWithFallbackToStaleData[String]()
+    an[Exception] must be thrownBy cache.get("a")
+
+    noException must be thrownBy cache.safeGet("a")
+    cache.safeGet("a").isFailure mustBe true
+  }
+
+  "getOrElse" in {
+    val cache = TestCacheWithFallbackToStaleData[String]()
+    an[Exception] must be thrownBy cache.get("a")
+
+    noException must be thrownBy cache.getOrElse("a", "default")
+    cache.getOrElse("a", "default") mustBe "default"
+
+    cache.set("b", "nonDefault")
+    cache.getOrElse("b", "default") mustBe "nonDefault"
+  }
+
 }


### PR DESCRIPTION
Provides utility function to help prevent the call to `get` from failing inadvertently.