### PR TITLE
Upgrade libraries joda-time, org.scalacheck

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,14 +11,14 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"
 
 libraryDependencies ++= Seq(
-  "joda-time" % "joda-time" % "2.10.6", // This is temporary, should use java.time.*
+  "joda-time" % "joda-time" % "2.10.8", // This is temporary, should use java.time.*
   "org.slf4j" % "slf4j-api" % "1.7.30",
   "org.joda" % "joda-convert" % "2.2.1",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "org.mockito" % "mockito-scala_2.13" % "1.11.3" % Test,
   "org.scalatest" %% "scalatest" % "3.2.2" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.14.3" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.15.0" % Test,
   "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
   compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.7.1" cross CrossVersion.full),
   "com.github.ghik" %% "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full,


### PR DESCRIPTION
- joda-time
  - joda-time (2.10.6 => 2.10.8)
- org.scalacheck
  - scalacheck (1.14.3 => 1.15.0)