### PR TITLE
Upgrade libraries org.scalatest, org.slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,12 +23,12 @@ resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"
 
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.10.13", // This is temporary, should use java.time.*
-  "org.slf4j" % "slf4j-api" % "1.7.32",
+  "org.slf4j" % "slf4j-api" % "1.7.35",
   "org.joda" % "joda-convert" % "2.2.2",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "org.mockito" % "mockito-scala_2.13" % "1.11.3" % Test,
-  "org.scalatest" %% "scalatest" % "3.2.10" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.11" % Test,
   "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
   "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
 )


### PR DESCRIPTION
- org.scalatest
  - scalatest (3.2.10 => 3.2.11)
- org.slf4j
  - slf4j-api (1.7.32 => 1.7.35)