### PR TITLE
FDTN-1143: Downgrade slf4j-api from 2.x to 1.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"
 
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.11.1", // This is temporary, should use java.time.*
-  "org.slf4j" % "slf4j-api" % "2.0.1",
+  "org.slf4j" % "slf4j-api" % "1.7.36", // Must follow Play - https://github.com/playframework/playframework/blob/2.8.x/project/Dependencies.scala#L52
   "org.joda" % "joda-convert" % "2.2.2",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",


### PR DESCRIPTION
While slf4j 2.x should be backwards compatible with 1.x, Play framework does not have a release that supports slf4j 2.x yet. The [fix](https://github.com/playframework/playframework/pull/11433) has been merged, and should be out in Play 2.8.17.
