### PR TITLE
[TAC-377] fix proportionallyAllocateRound

### DIFF
--- a/src/main/scala/io/flow/util/Allocator.scala
+++ b/src/main/scala/io/flow/util/Allocator.scala
@@ -96,7 +96,7 @@ object Allocator {
       val step = BigDecimal(10).pow(-scale)
       val zero = (delta, mutable.ListBuffer[(Int, BigDecimal)]())
       val (_, allocatedDeltas) = distancesSorted.foldLeft(zero) { case ((remaining, acc), (_, _, index)) =>
-        if (remaining <= 0)
+        if (remaining < step)
           (remaining, acc)
         else {
           val toAllocate = step.min(remaining.abs)

--- a/src/main/scala/io/flow/util/Allocator.scala
+++ b/src/main/scala/io/flow/util/Allocator.scala
@@ -96,7 +96,8 @@ object Allocator {
       val step = BigDecimal(10).pow(-scale)
       val zero = (delta, mutable.ListBuffer[(Int, BigDecimal)]())
       val (_, allocatedDeltas) = distancesSorted.foldLeft(zero) { case ((remaining, acc), (_, _, index)) =>
-        if (remaining < step)
+        // TAC-377: Proposed fix is `if (remaining < step)`
+        if (remaining <= 0)
           (remaining, acc)
         else {
           val toAllocate = step.min(remaining.abs)

--- a/src/test/scala/io/flow/util/AllocatorSpec.scala
+++ b/src/test/scala/io/flow/util/AllocatorSpec.scala
@@ -132,9 +132,9 @@ class AllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPrope
       test(Seq(1, 2)) shouldBe Seq(33, 67)
     }
 
-    "proportionallyAllocateRound" in {
-      Allocator.proportionallyAllocateRound(100, Seq(1, 2, 1), 2) shouldBe Seq(25, 50, 25)
-      Allocator.proportionallyAllocateRound(18.322125575615818, Seq(287.04663401798115, 54.64879321687011, 31.477411738907975), 2) shouldBe Seq(14.09, 2.68, 1.55)
+    "Expect all allocated values to be rounded" in {
+      Allocator.proportionallyAllocateRound(amount = 100, proportions = Seq(1, 2, 1), scale = 2) shouldBe Seq(25, 50, 25)
+      Allocator.proportionallyAllocateRound(amount = 18.322125575615818, proportions = Seq(287.04663401798115, 54.64879321687011, 31.477411738907975), scale = 2) shouldBe Seq(14.09, 2.68, 1.55)
     }
   }
 }

--- a/src/test/scala/io/flow/util/AllocatorSpec.scala
+++ b/src/test/scala/io/flow/util/AllocatorSpec.scala
@@ -131,6 +131,11 @@ class AllocatorSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPrope
       test(Seq(1, 1, 1)) shouldBe Seq(34, 33, 33)
       test(Seq(1, 2)) shouldBe Seq(33, 67)
     }
+
+    "proportionallyAllocateRound" in {
+      Allocator.proportionallyAllocateRound(100, Seq(1, 2, 1), 2) shouldBe Seq(25, 50, 25)
+      Allocator.proportionallyAllocateRound(18.322125575615818, Seq(287.04663401798115, 54.64879321687011, 31.477411738907975), 2) shouldBe Seq(14.09, 2.68, 1.55)
+    }
   }
 }
 


### PR DESCRIPTION
Previously the final part of the allocation was not being rounded effectively. This change will verify that any remain allocation should be `=>` than the `step` which in the case of 2 decimal places would be `0.01`. This change presumes we want to round down that final remainder for allocation purposes. If we prefer to round the remainder for allocation purposes this will need to be changed