### PR TITLE
FDN-3333 Post Play 2.9 Dependence Day

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "lib-util"
 
 organization := "io.flow"
 
-scalaVersion := "2.13.15"
+scalaVersion := "2.13.16"
 ThisBuild / javacOptions ++= Seq("-source", "17", "-target", "17")
 
 enablePlugins(GitVersioning)
@@ -34,8 +34,8 @@ licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 resolvers += "Artifactory" at "https://flow.jfrog.io/flow/libs-release/"
 
 libraryDependencies ++= Seq(
-  "joda-time" % "joda-time" % "2.12.7", // This is temporary, should use java.time.*
-  "org.slf4j" % "slf4j-api" % "1.7.36", // Must follow Play - https://github.com/playframework/playframework/blob/2.8.x/project/Dependencies.scala#L52
+  "joda-time" % "joda-time" % "2.13.0", // play-json 2.10.6 with Play 2.9.6
+  "org.slf4j" % "slf4j-api" % "2.0.16", // Must follow Play -https://github.com/playframework/playframework/blob/2.9.6/project/Dependencies.scala#L70
   "org.joda" % "joda-convert" % "3.0.1",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")


### PR DESCRIPTION

Getting versions updated after merging play296 branches of libraries to main.

Also upgrading to Scala 2.13.16 as scoverage 2.3.x pulls it in.  With our normal DD it opens two PRs but neither builds due to the Scala upgrade then causing a request for a version of scoverage that does not exist.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>