### PR TITLE
FDN-3369 Remove unnecessary logback-classic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
   "com.github.blemale" %% "scaffeine" % "5.3.0",
-  "ch.qos.logback" % "logback-classic" % "1.4.11" % Test,
   "org.mockito" % "mockito-scala_2.13" % "1.11.3" % Test,
   "org.scalatest" %% "scalatest" % "3.2.18" % Test,
   "org.scalacheck" %% "scalacheck" % "1.18.1" % Test,


### PR DESCRIPTION
Play itself brings in a later one
```
[info]   +-com.typesafe.play:play-logback_2.13:2.9.6 [S]
[info]   | +-ch.qos.logback:logback-classic:1.5.12
```
plus any lib management for logs can from from our lib-log